### PR TITLE
desktop styling on end page and highscore list styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,10 @@
     </div>
     
   <div class="waves"></div>
-    <dialog id="dialog">
-        <button id="closeModalButton"><i class="icon-close"></i></button>
-        <div id="dialogContent"></div>
-    </dialog>
+  
+  <dialog id="dialog">
+      <button id="closeModalButton"><i class="icon-close"></i></button>
+      <div id="dialogContent"></div>
+  </dialog>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -16,7 +16,7 @@ const categories = [
 let allQuestions;
 let selectedQuestions;
 const questionsFile = "./questionDataBase.questions.json";
-const questionAmount = 10;
+const questionAmount = 4;
 const savedAnswers = [];
 
 
@@ -49,7 +49,7 @@ function renderStartPage() {
   });
 
   quizApp.innerHTML = `
-    ${createTitle()}
+    <div class="start-page__title">${createTitle()}</div>
 
     <div class="categories-container">
       ${categoriesHTML}
@@ -65,9 +65,9 @@ function renderStartPage() {
   `;
 }
 
-function createTitle(forQuestionPage = false) {
+function createTitle() {
   return `
-      <hgroup class="title ${forQuestionPage ? "title-question-page" : ""}">
+      <hgroup class="title">
         <h1 class="title__heading">QuizMix</h1>
         <p class="title__subtitle">By Tech Titans</p>
         <div class="title__icon"><i class="icon icon-chat_bubbles"></i></div>
@@ -108,7 +108,7 @@ function renderQuestionPage(question) {
 
   // Add HTML content to the question wrapper
   questionWrapper.innerHTML = `
-    <div class="question__title">${createTitle(true)}</div>
+    <div class="title question__title">${createTitle()}</div>
 
       <div class="timer grow">
         <div class="timer__time" id="timer">10.0</div>
@@ -263,6 +263,9 @@ function addSlideIn(option, index) {
 /* ------------------------------------------------ */
 
 function renderEndPage() {
+  const endPageWrapper = document.createElement("div");
+  endPageWrapper.classList.add("end-page");
+
   savedAnswers.forEach((result) => {
     if (result.selectedAnswer === result.correctAnswer) {
       correctAnswersAmount++;
@@ -270,12 +273,20 @@ function renderEndPage() {
     }
   });
 
-  quizApp.innerHTML = `
-    <h2 class="points">
-      <div class="points__amount">${highScore}</div>
-      <div class="points__unit">poäng</div>
-    </h2>
-    <div class="score">${correctAnswersAmount}/${questionAmount} rätt</div>
+  endPageWrapper.innerHTML = `
+    <div class="end-page__title">${createTitle()}</div>
+
+    <div class="end-page__points">
+      <h2 class="points">
+        <div class="points__amount">${highScore}</div>
+        <div class="points__unit">poäng</div>
+      </h2>
+      <div class="score">${correctAnswersAmount}/${questionAmount} rätt</div>
+    </div>
+
+    <div class="end-page__results">
+      ${renderResult()}
+    </div>
 
     <div class="button-container">
       <button id="resultButton" class="button result-button">
@@ -294,6 +305,7 @@ function renderEndPage() {
       </button>
     </div>
 `;
+  quizApp.appendChild(endPageWrapper);
   saveToLocalStorage(highScore, currentCategory);
 }
 
@@ -302,33 +314,36 @@ function renderEndPage() {
 // RESULTS & HIGHSCORE
 /* ------------------------------------------------ */
 
+function renderResult() {
+  let resultHTML = "";
+
+  savedAnswers.forEach((result, i) => {
+    const isCorrect = result.selectedAnswer === result.correctAnswer;
+
+      resultHTML += `
+      <div class="result-item ${!isCorrect ? "result-item--wrong" : ""}">
+        <div class="result-item__question-number">${i + 1}</div>
+        <div class="result-item__question-text">${result.questionText}</div>
+        <div class="result-item__selected-answer" style="${isCorrect ? "grid-row:span 2":""}">${result.selectedAnswer}</div>
+        <div class="result-item__correct-answer ${!isCorrect ? "" : "hidden"}"><span class="underline">Korrekt svar:</span> ${result.correctAnswer}</div>
+        <div class="result-item__icon"><i class="${!isCorrect ? "icon-close" : "icon-check"}"></i></div>
+      </div>
+      `;
+    });
+
+    const resultsContainer = `
+      <div class="result-list">
+        <h2 class="result-title">Resultat</h2>
+        ${resultHTML}
+      </div>
+    `;
+
+    return resultsContainer;
+}
+
 function showResult() {
-  const resultsContainer = document.createElement("div");
-  resultsContainer.classList.add("result-list");
-
-  let resultHTML = "<h2>Resultat</h2>";
-
-    for(let i = 0; i < savedAnswers.length; i++){
-      const result = savedAnswers[i];
-      const isCorrect = result.selectedAnswer === result.correctAnswer;
-
-        resultHTML += `
-        <div class="result-item ${!isCorrect ? "result-item--wrong" : ""}">
-          <div class="result-item__question-number">${i + 1}</div>
-          <div class="result-item__question-text">${result.questionText}</div>
-          <div class="result-item__selected-answer" style="${isCorrect ? "grid-row:span 2":""}">${result.selectedAnswer}</div>
-          <div class="result-item__correct-answer ${!isCorrect ? "" : "hidden"}"><span class="underline">Korrekt svar:</span> ${result.correctAnswer}</div>
-          <div class="result-item__icon"><i class="${!isCorrect ? "icon-close" : "icon-check"}"></i></div>
-        </div>
-        `;
-      };
-
-    resultsContainer.innerHTML = resultHTML;
-
-    // Show in modal on mobile:
-    openModal();
-    dialogContent.appendChild(resultsContainer);
-    // TODO: On desktop, show on page
+  openModal();
+  dialogContent.innerHTML = renderResult();
 }
 
 function showHighscore() {
@@ -344,13 +359,15 @@ function showHighscore() {
       const highscore= highscoreData[i];
       const dateFormatted = highscore.date.split(" ")
 
-      const dateHTML = `<span>${dateFormatted[0]}</span> <span>${dateFormatted[1]}</span>`
+      const dateHTML = `<span>${dateFormatted[0]}</span> <span class="highscore__time">${dateFormatted[1]}</span>`
 
       highscoreHTML += `
         <div class="highscore">
           <div class="highscore__score">${i + 1}. ${highscore.highscore}p</div>
           <div class="highscore__date">${dateHTML}</div>
-          <i class="${findCategoryByName(highscore.category)?.icon}"></i>
+          <div class="highscore__icon ${findCategoryByName(highscore.category)?.class}" title="${highscore.category}">
+            <i class="icon ${findCategoryByName(highscore.category)?.icon}"></i>
+          </div>
         </div>
       `;
     };

--- a/styles/base.css
+++ b/styles/base.css
@@ -56,7 +56,7 @@ body {
 
 h2 {
     font-size: 1.8em;
-    color: #834E85;
+    color: white;
     text-align: center;
     font-weight: 800;
 }
@@ -69,12 +69,12 @@ h2 {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #bd9bcb;
+    background: #8dc6e4;
     border-radius: 5px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #a975b8;
+    background: #6498b4;
 }
 
 /* Dialog modal */
@@ -93,6 +93,11 @@ h2 {
     height: 100%;
     padding: 3rem;
     overflow: auto;
+}
+
+#dialog h2 {
+    color: #834E85;
+    text-shadow: none;
 }
 
 ::backdrop {
@@ -115,6 +120,7 @@ h2 {
       color: var(--close-modal-text-hover);
     }
 }
+
 
 /* Buttons */
 
@@ -208,7 +214,7 @@ h2 {
 /* Waves */
 
 .waves {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     z-index: -1;
@@ -221,6 +227,7 @@ h2 {
     background-repeat: repeat-x;
     background-size: 1600px 50%;
     background-position: 0 130%, -50px 130%, 500px 130%;
+    background-attachment: fixed;
     animation: 20s waves linear infinite forwards;
     opacity: .5;
 }

--- a/styles/end.css
+++ b/styles/end.css
@@ -1,3 +1,23 @@
+.end-page {
+  display: grid;
+}
+
+.end-page__title {
+  display: none;
+}
+
+.end-page__results {
+  display: none;
+  height: 20rem;
+  width: 40rem;
+  overflow: auto;
+  padding: 1rem;
+}
+
+.result-title {
+  text-shadow: 1px 1px 2px var(--body-text-shadow);
+}
+
 /*  Result */
 .result-list {
     display: flex;
@@ -18,7 +38,7 @@
 }
 
 .result-item--wrong {
-    background: linear-gradient(to right,#ED5276, #FF82C1);
+    background: linear-gradient(to right,#ED5276, #ff58d8);
 }
 
 .result-item--wrong .result-item__question-number {
@@ -67,6 +87,10 @@
 .result-item__icon {
     align-items: center;
     display: flex;
+}
+
+.result-item__correct-answer {
+  text-align: left;
 }
 
 .result-item__icon {
@@ -118,7 +142,7 @@
 /* Buttons */
 
 .button-container {
-    margin: 2rem;
+    padding: 2rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/styles/media-query.css
+++ b/styles/media-query.css
@@ -5,10 +5,15 @@
   }
 }
 
+/* Tablet */
 @media screen and (min-width: 900px) {
   .timer-progress {
     max-width: 90rem;
   }
+
+  /* .timer {
+    --max-size: 7rem;
+  } */
 }
 
 /* Desktop */
@@ -24,7 +29,7 @@
     position: relative;
   }
 
-  .title-question-page {
+  .title {
     margin-inline: auto;
     display: grid;
     font-size: clamp(1rem, 2vw + .5rem, 1.5rem);
@@ -83,6 +88,35 @@
     --max-size: 5rem;
     grid-column: 2;
     grid-row: 2;
+  }
+
+  .end-page {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: repeat(3, 1fr); 
+    gap: 0 4rem;
+  }
+
+  .end-page__title {
+    display: block;
+    grid-column: span 2;
+  }
+
+  .end-page__results {
+    display: block;
+  }
+
+  .button-container {
+    grid-column: span 2;
+    margin-inline: auto;
+  }
+
+  #resultButton {
+    display: none;
+  }
+
+  .score {
+    max-width: 20rem;
+    margin-inline: auto;
   }
 }
 

--- a/styles/question.css
+++ b/styles/question.css
@@ -9,6 +9,10 @@
     text-align: center;
 }
 
+.question__title {
+  display: none;
+}
+
 .question__text {
     -webkit-user-select: none;
     user-select: none;
@@ -159,7 +163,7 @@
 
 .timer {
     --max-size: 10rem;
-    --time-font-size: clamp(3rem, 10vmin + 1rem, var(--max-size));
+    --time-font-size: clamp(5rem, 8vmin + 1rem, var(--max-size));
     --space: 4rem;
     height: calc(var(--time-font-size) + var(--space));
     display: flex;

--- a/styles/start.css
+++ b/styles/start.css
@@ -49,7 +49,7 @@
 
 .highscore {
     display: flex;
-    justify-content: space-between;
+    gap: 2rem;
     background-color: #F1EBFF;
     border-radius: 13px;
     padding: 1rem;
@@ -59,10 +59,32 @@
     align-items: center;
 }
 
+.highscore__score {
+  margin-right: auto;
+}
+
 .highscore__date {
-    color: #A374C6;
+    color: #76409f;
     display: flex;
     flex-direction: column;
+}
+
+.highscore__time {
+  color: #A374C6;
+  font-weight: 500;
+  font-size: 1.3rem;
+}
+
+.highscore__icon {
+  padding: 1rem;
+  display: flex;
+  border-radius: 9px;
+  background: linear-gradient(var(--category-color-1), var(--category-color-2));
+}
+
+.highscore__icon .icon {
+  font-size: 2rem;
+  color: white;
 }
 
 /* Categories */


### PR DESCRIPTION
- Desktop media query styling for end page #75 
- Results show in a scrollable container while on desktop
- Created a `renderResult()` function that can be used by both `showResult()` to show results in a modal, as well as when rendering the end page so the results show directly on screen while on desktop
- Styled the high score list items #84 